### PR TITLE
feat: implement serialization methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Our project welcomes external contributions. If you have an itch, please feel
 free to scratch it.
 
-To contribute code or documentation, please submit a [pull request](https://github.com/DS4SD/docling/pulls).
+To contribute code or documentation, please submit a [pull request](https://github.com/DS4SD/docling-haystack/pulls).
 
 A good way to familiarize yourself with the codebase and contribution process is
 to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/DS4SD/docling/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Our project welcomes external contributions. If you have an itch, please feel
 free to scratch it.
 
-To contribute code or documentation, please submit a [pull request](https://github.com/DS4SD/docling-haystack/pulls).
+To contribute code or documentation, please submit a [pull request](https://github.com/DS4SD/docling/pulls).
 
 A good way to familiarize yourself with the codebase and contribution process is
 to look for and tackle low-hanging fruit in the [issue tracker](https://github.com/DS4SD/docling/issues).

--- a/docling_haystack/converter.py
+++ b/docling_haystack/converter.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable, Optional, Union
 from docling.chunking import BaseChunk, BaseChunker, HybridChunker
 from docling.datamodel.document import DoclingDocument
 from docling.document_converter import DocumentConverter
-from haystack import Document, component
+from haystack import Document, component, default_from_dict, default_to_dict
 
 
 class ExportType(str, Enum):
@@ -139,3 +139,29 @@ class DoclingConverter:
             else:
                 raise RuntimeError(f"Unexpected export type: {self._export_type}")
         return {"documents": documents}
+    
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the component to a dictionary for pipeline persistence.
+
+        Returns:
+            dict[str, Any]: A dictionary representation of the component
+        """
+        return default_to_dict(
+            self,
+            convert_kwargs=self._convert_kwargs,
+            md_export_kwargs=self._md_export_kwargs,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DoclingConverter":
+        """
+        Deserialize the component from a dictionary.
+
+        Args:
+            data: Dictionary representation of the component
+
+        Returns:
+            DoclingConverter: A new instance of the component
+        """
+        return default_from_dict(cls, data)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -80,3 +80,26 @@ def test_convert_markdown(monkeypatch):
     with open(EXPECTED_OUT_FILE) as f:
         exp_data = json.load(fp=f)
     assert exp_data == act_data
+
+
+def test_serialization_deserialization():
+    """Test component serialization and deserialization."""
+    converter = DoclingConverter(
+        convert_kwargs={"optimize_ocr": True},
+        md_export_kwargs={"image_placeholder": "[IMAGE]"},
+    )
+
+    # serialize the component to dict
+    serialized = converter.to_dict()
+
+    assert "init_parameters" in serialized
+    assert serialized["init_parameters"].get("convert_kwargs") == {"optimize_ocr": True}
+
+    md_export_kwargs = serialized["init_parameters"].get("md_export_kwargs", {})
+    assert md_export_kwargs.get("image_placeholder") == "[IMAGE]"
+
+    # deserialize back to component
+    deserialized = DoclingConverter.from_dict(serialized)
+    assert deserialized._convert_kwargs == {"optimize_ocr": True}
+
+    assert deserialized._md_export_kwargs.get("image_placeholder") == "[IMAGE]"


### PR DESCRIPTION
This pull request enhances the `DoclingConverter` class by adding introducing serialization & deserialization methods. It also updates the corresponding tests to ensure the new functionality is well-covered.

### Changes to `DoclingConverter`:

* **Serialization and deserialization**:
  - Introduced `to_dict` and `from_dict` methods to allow the `DoclingConverter` to be serialized and deserialized for pipeline persistence.